### PR TITLE
Change Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,4 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    versioning-strategy: increase


### PR DESCRIPTION
This makes it increase the minimum version of dependencies on updates, instead of only updating the lock file in most cases.